### PR TITLE
removed superfluous commas, to fix protobuf compilation

### DIFF
--- a/parameters.json
+++ b/parameters.json
@@ -767,7 +767,7 @@
           "read": true
         },
         "wet": {
-          "read": true,
+          "read": true
         }
       },
       "representation": "uint8"
@@ -879,11 +879,11 @@
       "access": {
         "dry": {
           "read": true,
-          "read_option": true,
+          "read_option": true
         },
         "wet": {
           "read": true,
-          "read_option": true,
+          "read_option": true
         }
       }
     },


### PR DESCRIPTION
json_to_proto failed due to extra commas (Ubuntu 22.04, python3.10.12)